### PR TITLE
fix: auto-resubscribe contract event watchers on error

### DIFF
--- a/pinner/src/contracts/contentRegistry.ts
+++ b/pinner/src/contracts/contentRegistry.ts
@@ -8,10 +8,19 @@ import {
   Transport,
   WalletClient,
   WatchContractEventOnLogsFn,
+  WatchContractEventReturnType,
 } from "viem";
 import contentRegistryAbi from "./abi/contentRegistry.abi.js";
+import defaultLogger from "../logger.js";
+
+// How long to wait after a subscription error before re-subscribing.
+const SUBSCRIPTION_RESTART_BACKOFF_MS = 5_000;
 
 export class ContentRegistryContract {
+  private _logger = defaultLogger.child({
+    context: ContentRegistryContract.name,
+  });
+
   private _publicClient: PublicClient;
   private _walletClient: WalletClient<Transport, Chain, Account>;
   private _contractAddress: Address;
@@ -73,6 +82,18 @@ export class ContentRegistryContract {
     return content;
   }
 
+  /**
+   * Subscribe to a contract event.
+   *
+   * Wraps viem's watchContractEvent with an onError handler that logs the
+   * error and re-establishes the subscription after a short backoff. Without
+   * this, a transient RPC/WebSocket disruption can silently kill the
+   * subscription — the pinner process keeps running but stops receiving
+   * events, and on-chain content registrations are dropped forever.
+   *
+   * Returns an unwatch function. Calling it stops the subscription and
+   * prevents further auto-restart.
+   */
   watchEvent<E extends ContractEventName<typeof contentRegistryAbi>>(
     eventName: E,
     callback: WatchContractEventOnLogsFn<
@@ -82,20 +103,67 @@ export class ContentRegistryContract {
         : ContractEventName<typeof contentRegistryAbi>,
       true
     >,
-  ) {
-    const unwatch = this._publicClient.watchContractEvent({
-      address: this._contractAddress,
-      abi: this._abi,
-      eventName: eventName,
-      onLogs: callback,
-    });
-    return unwatch;
+  ): WatchContractEventReturnType {
+    let currentUnwatch: WatchContractEventReturnType = () => {};
+    let stopped = false;
+
+    const subscribe = () => {
+      if (stopped) return;
+      this._logger.info({ eventName }, "Subscribing to contract event");
+      currentUnwatch = this._publicClient.watchContractEvent({
+        address: this._contractAddress,
+        abi: this._abi,
+        eventName: eventName,
+        onLogs: callback,
+        onError: (err) => {
+          this._logger.error(
+            { eventName, err },
+            "watchContractEvent error; will re-subscribe",
+          );
+          try {
+            currentUnwatch();
+          } catch (teardownErr) {
+            this._logger.warn(
+              { teardownErr },
+              "Error during subscription teardown",
+            );
+          }
+          // Probe RPC liveness in the background; restart regardless.
+          this._publicClient
+            .getBlockNumber()
+            .then((block) => {
+              this._logger.info(
+                { block: block.toString() },
+                "RPC is reachable",
+              );
+            })
+            .catch((rpcErr) => {
+              this._logger.error(
+                { rpcErr },
+                "RPC also failing while restarting subscription",
+              );
+            });
+          setTimeout(subscribe, SUBSCRIPTION_RESTART_BACKOFF_MS);
+        },
+      });
+    };
+
+    subscribe();
+
+    return () => {
+      stopped = true;
+      try {
+        currentUnwatch();
+      } catch {
+        // ignore teardown errors during shutdown
+      }
+    };
   }
 
   onContentRegistered(
     callback: (uploader: Address, cid: Hash) => Promise<unknown>,
   ) {
-    this.watchEvent("ContentRegistered", async (logs) => {
+    return this.watchEvent("ContentRegistered", async (logs) => {
       for (const log of logs) {
         await callback(log.args.uploader, log.args.CID);
       }

--- a/pinner/src/ens.ts
+++ b/pinner/src/ens.ts
@@ -7,6 +7,7 @@ import {
   Hash,
   hexToBytes,
   webSocket,
+  WatchContractEventReturnType,
 } from "viem";
 import { mainnet } from "viem/chains";
 import config from "./config.js";
@@ -17,6 +18,9 @@ const logger = defaultLogger.child({ module: "ens" });
 
 const ENS_PUBLIC_RESOLVER_CONTRACT_ADDRESS =
   "0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63";
+
+// How long to wait after a subscription error before re-subscribing.
+const SUBSCRIPTION_RESTART_BACKOFF_MS = 5_000;
 
 const wsTransport = webSocket(config.ETH_MAINNET_CHAIN_WS_URL, {
   reconnect: {
@@ -29,41 +33,101 @@ const publicClient = createPublicClient({
   transport: wsTransport,
 });
 
-export async function onEnsContentHashChanged(
+/**
+ * Subscribe to ENS ContenthashChanged events.
+ *
+ * Wraps viem's watchContractEvent with an onError handler that logs the
+ * error and re-establishes the subscription after a short backoff. Without
+ * this, a transient RPC/WebSocket disruption can silently kill the
+ * subscription — the pinner process keeps running but stops receiving ENS
+ * events, and content-hash updates are dropped forever.
+ *
+ * Returns an unwatch function. Calling it stops the subscription and
+ * prevents further auto-restart.
+ */
+export function onEnsContentHashChanged(
   callback: (uploader: Address, cid: Hash) => Promise<void>,
-) {
+): WatchContractEventReturnType {
   logger.info(
     `Watching ENS ContenthashChanged events with url: ${config.ETH_MAINNET_CHAIN_WS_URL.slice(0, 20)}...`,
   );
-  publicClient.watchContractEvent({
-    abi: ensPublicResolverAbi,
-    address: ENS_PUBLIC_RESOLVER_CONTRACT_ADDRESS,
-    eventName: "ContenthashChanged",
-    onLogs: async (logs) => {
-      for (const log of logs) {
-        const l = logger.child({ log, tx: log.transactionHash });
-        l.info("Received ENS ContenthashChanged event");
-        const args = log.args;
-        const hash = args.hash;
-        if (!hash || !args.node) {
-          l.info("Skipping ENS ContenthashChanged event due to missing args");
-          continue;
+
+  let currentUnwatch: WatchContractEventReturnType = () => {};
+  let stopped = false;
+
+  const subscribe = () => {
+    if (stopped) return;
+    logger.info("Subscribing to ENS ContenthashChanged");
+    currentUnwatch = publicClient.watchContractEvent({
+      abi: ensPublicResolverAbi,
+      address: ENS_PUBLIC_RESOLVER_CONTRACT_ADDRESS,
+      eventName: "ContenthashChanged",
+      onLogs: async (logs) => {
+        for (const log of logs) {
+          const l = logger.child({ log, tx: log.transactionHash });
+          l.info("Received ENS ContenthashChanged event");
+          const args = log.args;
+          const hash = args.hash;
+          if (!hash || !args.node) {
+            l.info("Skipping ENS ContenthashChanged event due to missing args");
+            continue;
+          }
+          const tx = await publicClient.getTransactionReceipt({
+            hash: log.transactionHash,
+          });
+          const uploader = tx.from;
+          const codec = contentHash.getCodec(hash);
+          if (codec !== "ipfs") {
+            l.info({ codec }, `Skipping.. received ${codec} codec`);
+            continue;
+          }
+          const bytes = hexToBytes(hash);
+          const [, offset] = varint.decode(bytes);
+          const value = bytes.slice(offset);
+          const hexCid = bytesToHex(value);
+          await callback(uploader, hexCid);
         }
-        const tx = await publicClient.getTransactionReceipt({
-          hash: log.transactionHash,
-        });
-        const uploader = tx.from;
-        const codec = contentHash.getCodec(hash);
-        if (codec !== "ipfs") {
-          l.info({ codec }, `Skipping.. received ${codec} codec`);
-          continue;
+      },
+      onError: (err) => {
+        logger.error(
+          { err },
+          "ENS watchContractEvent error; will re-subscribe",
+        );
+        try {
+          currentUnwatch();
+        } catch (teardownErr) {
+          logger.warn(
+            { teardownErr },
+            "Error during ENS subscription teardown",
+          );
         }
-        const bytes = hexToBytes(hash);
-        const [, offset] = varint.decode(bytes);
-        const value = bytes.slice(offset);
-        const hexCid = bytesToHex(value);
-        await callback(uploader, hexCid);
-      }
-    },
-  });
+        publicClient
+          .getBlockNumber()
+          .then((block) => {
+            logger.info(
+              { block: block.toString() },
+              "Mainnet RPC is reachable",
+            );
+          })
+          .catch((rpcErr) => {
+            logger.error(
+              { rpcErr },
+              "Mainnet RPC also failing while restarting subscription",
+            );
+          });
+        setTimeout(subscribe, SUBSCRIPTION_RESTART_BACKOFF_MS);
+      },
+    });
+  };
+
+  subscribe();
+
+  return () => {
+    stopped = true;
+    try {
+      currentUnwatch();
+    } catch {
+      // ignore teardown errors during shutdown
+    }
+  };
 }


### PR DESCRIPTION
## Summary

Production pinner has been silently dropping on-chain events. Root cause: `watchContractEvent` is called with no `onError` handler in either the `ContentRegistryContract` or the ENS watcher, so when the underlying WebSocket subscription hits any error (network blip, RPC restart, rate limit), the subscription dies silently while the process keeps running.

This PR adds an `onError` handler that **tears down the dead subscription and re-subscribes after a 5 s backoff** in both watchers.

## Evidence (from production data)

Comparing the WebHash MySQL site registry (`webhash-websites.w3_edit_template_list.IPFS_CID`) against the AWS pinner node's recursive pins shows a long outage where no on-chain events were caught:

| Month | Sites registered (MySQL) | Pinned on AWS | % OK |
|---|---:|---:|---:|
| 2025-01 | 59 | 28 | 47.5% |
| **2025-02** | **35** | **0** | **0%** ← outage begins |
| **2025-03** | **4,419** | **0** | **0%** ← peak miss |
| **2025-04** | **75** | **7** | **9.3%** |
| **2025-05** | **34** | **5** | **14.7%** |
| 2025-06 | 19 | 19 | 100% ← recovered (process restart) |
| 2025-07 → today | ~700 | ~700 | ~100% |

**4,582 of the 5,076 CIDs registered in 2025 are missing from the pinner** (90.3% loss for that year). 99% of the missing CIDs have **zero providers on the public IPFS DHT** today — they're not recoverable from the network. The pinner kept running the whole time; logs show repeating `ErrorEvent` from viem's WebSocket transport while the subscription was effectively dead.

## What changed

- **`pinner/src/contracts/contentRegistry.ts`**: `watchEvent` now wraps `watchContractEvent` with an `onError` that logs, tears down `currentUnwatch()`, and calls a `subscribe()` closure again after 5 s. Returns an unwatch fn that also halts the auto-restart loop.
- **`pinner/src/ens.ts`**: same pattern applied to the inline `watchContractEvent` call. The function now returns an unwatch fn (previously `void`).
- On every error, also non-blocking-probes `getBlockNumber()` so RPC-side failures are visible in logs.

## Tested

- `bun install --frozen-lockfile` ✓
- `bun run build` (tsc) ✓ — types compile clean
- `bun run bundle` ✓ — produces `dist/main.js` (1.31 MB)
- No new runtime deps

## Supersedes

The `fix/silent-error` branch (commits `9ae79c2`, `7588ece`) added `onError` *logging* but did not re-establish the subscription, so it wouldn't have prevented the outage. This PR includes the resubscribe behavior and can replace that branch.

## Suggested follow-ups (not in this PR)

- Add a periodic heartbeat log (e.g. every 5 min) emitting the latest block seen, so silent drift becomes externally monitorable.
- Add an integration test that injects a WS disconnect and asserts events resume.
- Consider `viem`'s polling fallback (`poll: true`) as an additional safety net for chains/providers where WebSocket subscriptions are unreliable.