### PR TITLE
chore: bump kubo image to v0.41.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   node:
     container_name: node
-    image: ipfs/kubo:v0.34.1
+    image: ipfs/kubo:v0.41.0
     privileged: true
     ports:
       - "4001:4001" # IPFS swarm (TCP)


### PR DESCRIPTION
## Summary

Bumps `ipfs/kubo` image from `v0.34.1` to `v0.41.0`.

## Why

`v0.34.1` ships with a libp2p version that crashes under bitswap load:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x16fcce6]
goroutine ... [running]:
created by github.com/libp2p/go-libp2p/p2p/net/swarm.(*Conn).start.func1
```

In production on the WebHash AWS node, `docker inspect node` showed `RestartCount: 5` over the lifetime of the running container — and each crash dropped in-flight `ipfs pin add` requests with `Error: EOF`. The container's `restart: always` policy hid the issue from `docker ps` (uptime kept resetting to a healthy value within seconds).

## Verified in production

This image was already deployed on the AWS node earlier today. Result:

- Built-in `--migrate=true` flag (already set in the compose `command` for `kubo`) performed repo migration `v16 → v17 → v18` cleanly.
- 4,600 existing recursive pins preserved (`ipfs pin ls --type=recursive | wc -l` before/after match).
- Daemon health: `docker inspect node` reports `Health: healthy`, no panics in logs since.
- DHT participation (`ipfs stats provide`, `ipfs swarm peers`) and gateway functionality unchanged.
- AutoTLS and p2p-forge certs continued to function.

## Migration notes

On nodes still running `v0.34.1`, the upgrade is a single line of work plus a brief restart:

```bash
cd /opt/webhash-node/repo
git pull --ff-only origin main
docker compose pull node
docker compose up -d --no-deps node
```

The container CMD already includes `--migrate=true`, so the repo will migrate on first start. Total downtime in the AWS production upgrade: ~12 seconds.

### Safety: take a snapshot first

Repo migrations are irreversible. Before pulling on a node with valuable data, take an instant hard-link snapshot of the repo:

```bash
cp -al /root/.webhash-node-data/ipfs /root/.webhash-node-data/ipfs.bak.$(date -u +%Y%m%d)
```

`cp -al` uses zero extra disk (hard links) and gives you a rollback path if the migration goes sideways.